### PR TITLE
Fix build error for Arch Linux

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -32,6 +32,7 @@ prepare() {
   cp -r . "${srcdir}/${_pkgbase}/cmake"
   cd "${srcdir}/${_dbusmenuname}"
   cp -r . "${srcdir}/${_pkgbase}/dbusmenu"
+  rm "${srcdir}/vala-panel-appmenu/vapi/glib-2.0.vapi"
 }
 
 build() {


### PR DESCRIPTION
glib-2.0.vapi seems to be causing errors with build. Removing it for now.