### PR TITLE
Remove some vertical padding

### DIFF
--- a/lib/appmenu.css
+++ b/lib/appmenu.css
@@ -5,6 +5,12 @@
     box-shadow: inset 0 0px;
 }
 
+.-vala-panel-appmenu-private > menuitem {
+    margin: 0 0 0 0;
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
 .-vala-panel-appmenu-bold:first-child > * > label {
   font-weight: bolder;
 }

--- a/lib/appmenu.css
+++ b/lib/appmenu.css
@@ -5,8 +5,11 @@
     box-shadow: inset 0 0px;
 }
 
-.-vala-panel-appmenu-private > menuitem {
-    margin: 0 0 0 0;
+scrolledwindow,
+.-vala-panel-appmenu-private > menuitem,
+.-vala-panel-appmenu-private:first-child > * > label {
+    margin-top: 0;
+    margin-bottom: 0;
     padding-top: 0;
     padding-bottom: 0;
 }


### PR DESCRIPTION
After adding scrolling feature, if panel is too thin, scroller make menubar scrollable vertically, even though policy is NEVER.

This is first step to make it happy with thin panels - at least with minwaita theme it is ok at panel thickness 
down to 17.